### PR TITLE
fix: restore standalone login on macOS

### DIFF
--- a/src/open_claude_design/auth.py
+++ b/src/open_claude_design/auth.py
@@ -39,6 +39,7 @@ from open_claude_design.config import (
     CLAUDE_DESIGN_STANDALONE_CREDENTIAL_PARTS,
     CLAUDE_DESIGN_STANDALONE_KEYCHAIN_ACCOUNT,
     CLAUDE_DESIGN_STANDALONE_KEYCHAIN_SERVICE,
+    CLAUDE_DESIGN_USER_AGENT,
 )
 
 
@@ -382,7 +383,11 @@ def _request_token(
     request = urllib.request.Request(
         CLAUDE_DESIGN_OAUTH_TOKEN_URL,
         data=json.dumps(fields).encode("utf-8"),
-        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": CLAUDE_DESIGN_USER_AGENT,
+        },
         method="POST",
     )
     try:

--- a/src/open_claude_design/auth.py
+++ b/src/open_claude_design/auth.py
@@ -27,6 +27,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 from open_claude_design.config import (
     CLAUDE_DESIGN_BROWSER_LOGIN_ENV,
     CLAUDE_DESIGN_CREDENTIAL_MAX_BYTES,
+    CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES,
     CLAUDE_DESIGN_OAUTH_AUTHORIZE_URL,
     CLAUDE_DESIGN_OAUTH_CLIENT_ID,
     CLAUDE_DESIGN_OAUTH_MANUAL_REDIRECT_URL,
@@ -190,10 +191,16 @@ def _read_keychain(
     )
     if result.returncode != 0:
         return None
+    stored = result.stdout.rstrip("\n")
     try:
-        payload = json.loads(result.stdout)
+        payload = json.loads(stored)
     except json.JSONDecodeError as error:
-        raise DesignAuthError("Open Claude Design's Keychain credential is not valid JSON.") from error
+        # _write_keychain stores the credential base64-wrapped; a credential written by
+        # an earlier version is still raw JSON, so both forms have to keep loading.
+        try:
+            payload = json.loads(base64.b64decode(stored, validate=True).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            raise DesignAuthError("Open Claude Design's Keychain credential is not valid JSON.") from error
     if not isinstance(payload, dict):
         raise DesignAuthError("Open Claude Design's Keychain credential must contain a JSON object.")
     return payload
@@ -237,24 +244,35 @@ def _write_keychain(
     payload: dict[str, object],
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> None:
+    # `add-generic-password -w` with the secret on stdin cannot carry a credential:
+    # its prompt reads through readpassphrase(3), which silently keeps only the first
+    # 128 bytes and still exits 0, and it reads /dev/tty instead of stdin whenever a
+    # controlling terminal exists, so an interactive login blocks on a password prompt.
+    # `security -i` takes the whole command on stdin instead, which has neither
+    # behaviour. The credential is base64-wrapped so it stays a single unquoted token
+    # for the batch parser; _read_keychain unwraps it.
     serialized = json.dumps(payload, separators=(",", ":"))
+    encoded = base64.b64encode(serialized.encode("utf-8")).decode("ascii")
+    command = (
+        "add-generic-password -U "
+        f'-a "{CLAUDE_DESIGN_STANDALONE_KEYCHAIN_ACCOUNT}" '
+        f'-s "{CLAUDE_DESIGN_STANDALONE_KEYCHAIN_SERVICE}" '
+        f"-w {encoded}\n"
+    )
+    if len(command.encode("utf-8")) > CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES:
+        # Past the batch line limit `security` would split the credential and echo a
+        # fragment of it back as an "unknown command" error. Refuse instead.
+        raise DesignAuthError("The Design credential is too large for the macOS Keychain batch interface.")
     result = runner(
-        [
-            "/usr/bin/security",
-            "add-generic-password",
-            "-U",
-            "-a",
-            CLAUDE_DESIGN_STANDALONE_KEYCHAIN_ACCOUNT,
-            "-s",
-            CLAUDE_DESIGN_STANDALONE_KEYCHAIN_SERVICE,
-            "-w",
-        ],
-        input=f"{serialized}\n{serialized}\n",
+        ["/usr/bin/security", "-i"],
+        input=command,
         capture_output=True,
         text=True,
         shell=False,
         timeout=30,
         check=False,
+        # No controlling terminal, so `security` can never fall back to a /dev/tty prompt.
+        start_new_session=True,
     )
     if result.returncode != 0:
         raise DesignAuthError("Could not save the Design credential to macOS Keychain.")

--- a/src/open_claude_design/bridge.py
+++ b/src/open_claude_design/bridge.py
@@ -62,6 +62,7 @@ from open_claude_design.config import (
     CLAUDE_DESIGN_SYNC_SCHEMA_VERSION,
     CLAUDE_DESIGN_SYNC_STALE_EXIT_CODE,
     CLAUDE_DESIGN_SYNC_UNKNOWN_EXIT_CODE,
+    CLAUDE_DESIGN_USER_AGENT,
     DEFAULT_FILE_LIST_DEPTH,
     VERSION,
 )
@@ -366,6 +367,7 @@ class ClaudeDesignClient:
             "Authorization": f"Bearer {self._token()}",
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
+            "User-Agent": CLAUDE_DESIGN_USER_AGENT,
         }
         if self._session_id:
             headers["Mcp-Session-Id"] = self._session_id

--- a/src/open_claude_design/config.py
+++ b/src/open_claude_design/config.py
@@ -24,6 +24,10 @@ CLAUDE_DESIGN_OAUTH_REFRESH_MARGIN_SECONDS: Final = 2 * 60
 CLAUDE_DESIGN_OAUTH_RESPONSE_MAX_BYTES: Final = 1024 * 1024
 CLAUDE_DESIGN_STANDALONE_KEYCHAIN_SERVICE: Final = "Open Claude Design-credentials"
 CLAUDE_DESIGN_STANDALONE_KEYCHAIN_ACCOUNT: Final = "open-claude-design"
+# `security -i` reads one batch command per line and discards whatever exceeds 4096
+# bytes, re-parsing the remainder as a new command. _write_keychain refuses to write
+# rather than let a credential be split across that boundary.
+CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES: Final = 4096
 CLAUDE_DESIGN_STANDALONE_CREDENTIAL_PARTS: Final = (".config", "open-claude-design", "credentials.json")
 CLAUDE_DESIGN_DURABLE_PREVIEW_HOSTS: Final = frozenset({"claude.ai", "www.claude.ai"})
 CLAUDE_DESIGN_SERVE_PREVIEW_HOST_SUFFIX: Final = "claudeusercontent.com"

--- a/src/open_claude_design/config.py
+++ b/src/open_claude_design/config.py
@@ -7,6 +7,10 @@ from typing import Final
 PACKAGE_NAME: Final = "open-claude-design"
 VERSION: Final = "1.1.0"
 
+# Cloudflare in front of the OAuth token endpoint rejects urllib's default
+# "Python-urllib/3.x" agent with Error 1010, so every request must send a product agent.
+CLAUDE_DESIGN_USER_AGENT: Final = f"{PACKAGE_NAME}/{VERSION}"
+
 CLAUDE_DESIGN_ENDPOINT: Final = "https://api.anthropic.com/v1/design/mcp"
 CLAUDE_DESIGN_OAUTH_AUTHORIZE_URL: Final = "https://claude.com/cai/oauth/authorize"
 CLAUDE_DESIGN_OAUTH_TOKEN_URL: Final = "https://platform.claude.com/v1/oauth/token"

--- a/tests/bridge/test_claude_design.py
+++ b/tests/bridge/test_claude_design.py
@@ -27,6 +27,7 @@ from open_claude_design.bridge import (
     read_design_credential,
     run_design_command,
 )
+from open_claude_design.config import CLAUDE_DESIGN_USER_AGENT
 
 pytestmark = pytest.mark.unit
 
@@ -274,10 +275,12 @@ def test_client_lists_tools_progressively_without_returning_token() -> None:
         ]
     )
     seen_authorization: list[str] = []
+    seen_user_agent: list[str | None] = []
 
     def opener(request: Any, *, timeout: int) -> FakeResponse:
         assert timeout == 30
         seen_authorization.append(request.headers["Authorization"])
+        seen_user_agent.append(request.get_header("User-agent"))
         if request.headers.get("Mcp-session-id"):
             assert request.headers["Mcp-session-id"] == "session-1"
         return next(responses)
@@ -287,6 +290,8 @@ def test_client_lists_tools_progressively_without_returning_token() -> None:
 
     assert tools[0]["name"] == "read_file"
     assert seen_authorization == ["Bearer secret-access-token"] * 3
+    # A default urllib agent is what Cloudflare rejects with Error 1010.
+    assert seen_user_agent == [CLAUDE_DESIGN_USER_AGENT] * 3
     assert "secret-access-token" not in json.dumps(tools)
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 import threading
 import urllib.request
+from collections.abc import Callable
 from email.message import Message
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,7 @@ import pytest
 
 import open_claude_design.auth as auth
 from open_claude_design.config import (
+    CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES,
     CLAUDE_DESIGN_OAUTH_CLIENT_ID,
     CLAUDE_DESIGN_OAUTH_MANUAL_REDIRECT_URL,
     CLAUDE_DESIGN_OAUTH_SCOPES,
@@ -303,6 +305,27 @@ def test_refresh_uses_stored_client_and_rotates_credential(tmp_path: Path) -> No
     assert requests[0]["refresh_token"] == "old-refresh"
 
 
+def _fake_keychain(
+    store: dict[str, str],
+) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Model the `security` batch write and password read this module relies on."""
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command[1:] == ["-i"]:
+            line = str(kwargs["input"])
+            if len(line.encode("utf-8")) > CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES:
+                return subprocess.CompletedProcess(command, 1, "", "security: unknown command")
+            store["password"] = line.rstrip("\n").rsplit(" -w ", 1)[1]
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if "find-generic-password" in command:
+            if "password" not in store:
+                return subprocess.CompletedProcess(command, 44, "", "")
+            return subprocess.CompletedProcess(command, 0, f"{store['password']}\n", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    return runner
+
+
 def test_keychain_write_keeps_tokens_out_of_argv() -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -319,8 +342,52 @@ def test_keychain_write_keeps_tokens_out_of_argv() -> None:
     command, kwargs = calls[0]
     assert "secret-access" not in " ".join(command)
     assert "secret-refresh" not in " ".join(command)
-    assert str(kwargs["input"]).count("secret-access") == 2
+    assert "secret-access" not in str(kwargs["input"])
     assert kwargs["shell"] is False
+    # `security` must not be able to reach a terminal, or it prompts instead of reading stdin.
+    assert kwargs["start_new_session"] is True
+
+
+def test_keychain_roundtrips_a_credential_larger_than_the_prompt_buffer() -> None:
+    # `add-generic-password -w` keeps only the first 128 bytes of a piped secret, so a
+    # real credential has to survive a write/read cycle well past that boundary.
+    payload = {
+        "designOauth": {
+            "accessToken": "a" * 1200,
+            "refreshToken": "r" * 600,
+            "scopes": list(CLAUDE_DESIGN_OAUTH_SCOPES),
+        }
+    }
+    runner = _fake_keychain({})
+
+    auth.save_standalone_credential(payload, platform="darwin", runner=runner)
+    stored = auth._read_keychain(runner)
+
+    assert stored == payload
+
+
+def test_keychain_read_still_loads_a_legacy_plain_json_credential() -> None:
+    payload = {"designOauth": {"accessToken": "legacy-access"}}
+    runner = _fake_keychain({"password": json.dumps(payload, separators=(",", ":"))})
+
+    assert auth._read_keychain(runner) == payload
+
+
+def test_keychain_read_rejects_an_unreadable_credential() -> None:
+    runner = _fake_keychain({"password": "not-json-and-not-base64-json"})
+
+    with pytest.raises(auth.DesignAuthError, match="not valid JSON"):
+        auth._read_keychain(runner)
+
+
+def test_keychain_write_refuses_a_credential_past_the_batch_line_limit() -> None:
+    oversized = {"designOauth": {"accessToken": "a" * CLAUDE_DESIGN_KEYCHAIN_BATCH_LINE_MAX_BYTES}}
+
+    def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        pytest.fail("an oversized credential must not reach `security`")
+
+    with pytest.raises(auth.DesignAuthError, match="too large"):
+        auth.save_standalone_credential(oversized, platform="darwin", runner=runner)
 
 
 def test_token_request_sends_a_product_user_agent(tmp_path: Path) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,6 +21,7 @@ from open_claude_design.config import (
     CLAUDE_DESIGN_OAUTH_CLIENT_ID,
     CLAUDE_DESIGN_OAUTH_MANUAL_REDIRECT_URL,
     CLAUDE_DESIGN_OAUTH_SCOPES,
+    CLAUDE_DESIGN_USER_AGENT,
 )
 
 pytestmark = pytest.mark.unit
@@ -320,6 +321,34 @@ def test_keychain_write_keeps_tokens_out_of_argv() -> None:
     assert "secret-refresh" not in " ".join(command)
     assert str(kwargs["input"]).count("secret-access") == 2
     assert kwargs["shell"] is False
+
+
+def test_token_request_sends_a_product_user_agent(tmp_path: Path) -> None:
+    # Cloudflare answers the default "Python-urllib/3.x" agent with Error 1010, which
+    # surfaces as "authorization was rejected (HTTP 403)" and fails every login.
+    seen: list[str | None] = []
+    messages: list[str] = []
+
+    def opener(request: urllib.request.Request, *, timeout: int) -> FakeResponse:
+        seen.append(request.get_header("User-agent"))
+        return FakeResponse(_token_response())
+
+    def reply(_prompt: str) -> str:
+        authorize_url = next(line for line in messages if line.startswith("https://"))
+        state = parse_qs(urlparse(authorize_url).query)["state"][0]
+        return f"authorization-code#{state}"
+
+    auth.login_design(
+        manual=True,
+        platform="linux",
+        home=tmp_path,
+        token_opener=opener,
+        input_reader=reply,
+        emit=messages.append,
+    )
+
+    assert seen == [CLAUDE_DESIGN_USER_AGENT]
+    assert "python-urllib" not in str(seen[0]).lower()
 
 
 def test_authorize_url_is_registered_public_client_with_exact_design_scopes() -> None:


### PR DESCRIPTION
## Summary

`open-claude-design login` cannot complete on macOS today. Two independent defects sit back to back in the login path, so fixing either one alone still leaves the CLI unusable:

**1. Cloudflare rejects the OAuth token request (all platforms).** The token exchange goes out with urllib's default `Python-urllib/3.x` agent, which Cloudflare answers with Error 1010 (`Access denied ... based on your browser's signature`). Every login ends at:

```
✗ Claude Design authorization was rejected (HTTP 403).
```

Verified against the live endpoint — same request, only the agent differs:

| `User-Agent` | Response |
| --- | --- |
| default (`Python-urllib/3.x`) | `403` + Cloudflare `error-1010` body |
| any explicit product agent | `400 invalid_grant` (reaches the real OAuth backend) |

**2. The macOS Keychain write truncates the credential to 128 bytes.** `security add-generic-password -w` with the secret piped on stdin cannot carry an OAuth credential:

- Its password prompt reads through `readpassphrase(3)`, which keeps only the first **128 bytes** and still **exits 0**. A credential is ~2 KB, so the login reported success and stored a truncated blob; the next command then failed with `Open Claude Design's Keychain credential is not valid JSON.`
- That prompt reads `/dev/tty` whenever a controlling terminal exists, ignoring the piped stdin, so an interactive login printed `password data for new item:` and blocked until the 30s timeout.

Measured on macOS 26.5 — the boundary is exact, and the failure is silent:

| Secret length | Stored length | `returncode` |
| ---: | ---: | ---: |
| 128 B | 128 B | 0 |
| 129 B | 128 B | 0 |
| 2000 B | 128 B | 0 |

### The fix

- A shared `CLAUDE_DESIGN_USER_AGENT` (`open-claude-design/<version>`) on the token request and on every MCP bridge request. The bridge posts to a host that does not currently block it, but it has the same exposure.
- The Keychain write moves to `security -i` batch mode, which has neither behaviour, and the secret still never appears in argv. `start_new_session=True` removes the controlling terminal so the prompt path is unreachable.
- The credential is base64-wrapped so it stays one unquoted token for the batch parser. **The read path accepts both the wrapped and the legacy plain-JSON form, so an existing credential keeps working** — no forced re-login.
- The batch parser discards whatever exceeds 4096 bytes on a line and re-parses the remainder as a new command, which echoes a fragment of the credential back inside an `unknown command` error. An oversized credential is now refused before it reaches `security` rather than being split or leaked. The ceiling leaves ~3 KB of credential headroom against a current ~2 KB.

Happy to split this into two PRs if you would rather take the agent fix on its own — the commits are already separated that way.

## Verification

- [x] `pytest -q` — 171 passed
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `basedpyright` — 0 errors (1 pre-existing `yaml` stub warning in `scripts/validate_skills.py`)
- [x] `python scripts/validate_skills.py` — validated 5 skills
- [x] Installed-artifact behavior exercised: with these changes a real `login` completes and `status --json` returns `authenticated: true` with both design scopes against the live API, reading the base64-wrapped credential back out of the Keychain.

Each new test was mutation-checked — reverting the corresponding fix makes it fail:

| Reverted | Failing test |
| --- | --- |
| the `User-Agent` header | `test_token_request_sends_a_product_user_agent` |
| the whole keychain write | 3 keychain tests |
| `start_new_session` | `test_keychain_write_keeps_tokens_out_of_argv` |
| the base64 read fallback | `test_keychain_roundtrips_a_credential_larger_than_the_prompt_buffer` |
| the plain-JSON read path | `test_keychain_read_still_loads_a_legacy_plain_json_credential` |

Ran with the repo's config but a locally installed toolchain rather than `uv run` — this machine's network blocks PyPI (`tls handshake eof`), so `uv sync` could not populate the venv. `shfmt` and `trivy` are not installed locally either, so `check-shell.sh` and `security-check.sh` were skipped; no shell scripts are touched by this change and CI remains the gate.

## Scope and safety

- [x] The change is focused and includes affected documentation.
- [x] Agent skills remain portable and implicitly invokable.
- [x] No credentials, plan tokens, private project content, or short-lived preview URLs are included.
- [x] Remote mutation behavior remains explicit, conflict-aware, and verified.
